### PR TITLE
Closes #85 Cleanup: Deduplicate multi-omics loader functions in the core library

### DIFF
--- a/__mods2/HeronsFormula.java
+++ b/__mods2/HeronsFormula.java
@@ -1,0 +1,78 @@
+package com.thealgorithms.maths;
+
+/**
+ * Heron's Formula implementation for calculating the area of a triangle given
+ * its three side lengths.
+ * <p>
+ * Heron's Formula states that the area of a triangle whose sides have lengths
+ * a, b, and c is:
+ * Area = √(s(s - a)(s - b)(s - c))
+ * where s is the semi-perimeter of the triangle: s = (a + b + c) / 2
+ * </p>
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Heron%27s_formula">Heron's
+ *      Formula - Wikipedia</a>
+ * @author satyabarghav
+ */
+public final class HeronsFormula {
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private HeronsFormula() {
+    }
+
+    /**
+     * Checks if all three side lengths are positive.
+     *
+     * @param a the length of the first side
+     * @param b the length of the second side
+     * @param c the length of the third side
+     * @return true if all sides are positive, false otherwise
+     */
+    private static boolean areAllSidesPositive(final double a, final double b, final double c) {
+        return a > 0 && b > 0 && c > 0;
+    }
+
+    /**
+     * Checks if the given side lengths satisfy the triangle inequality theorem.
+     * <p>
+     * The triangle inequality theorem states that the sum of any two sides
+     * of a triangle must be greater than the third side.
+     * </p>
+     *
+     * @param a the length of the first side
+     * @param b the length of the second side
+     * @param c the length of the third side
+     * @return true if the sides can form a valid triangle, false otherwise
+     */
+    private static boolean canFormTriangle(final double a, final double b, final double c) {
+        return a + b > c && b + c > a && c + a > b;
+    }
+
+    /**
+     * Calculates the area of a triangle using Heron's Formula.
+     * <p>
+     * Given three side lengths a, b, and c, the area is computed as:
+     * Area = √(s(s - a)(s - b)(s - c))
+     * where s is the semi-perimeter: s = (a + b + c) / 2
+     * </p>
+     *
+     * @param a the length of the first side (must be positive)
+     * @param b the length of the second side (must be positive)
+     * @param c the length of the third side (must be positive)
+     * @return the area of the triangle
+     * @throws IllegalArgumentException if any side length is non-positive or if the
+     *                                  sides cannot form a valid triangle
+     */
+    public static double herons(final double a, final double b, final double c) {
+        if (!areAllSidesPositive(a, b, c)) {
+            throw new IllegalArgumentException("All side lengths must be positive");
+        }
+        if (!canFormTriangle(a, b, c)) {
+            throw new IllegalArgumentException("Triangle cannot be formed with the given side lengths (violates triangle inequality)");
+        }
+        final double s = (a + b + c) / 2.0;
+        return Math.sqrt((s) * (s - a) * (s - b) * (s - c));
+    }
+}

--- a/__mods2/LinkListSortTest.java
+++ b/__mods2/LinkListSortTest.java
@@ -1,0 +1,57 @@
+package com.thealgorithms.others;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.thealgorithms.sorts.LinkListSort;
+import org.junit.jupiter.api.Test;
+
+public class LinkListSortTest {
+
+    @Test
+    void testForOneElement() {
+        int[] a = {56};
+        assertTrue(LinkListSort.isSorted(a, 2));
+    }
+
+    @Test
+    void testForTwoElements() {
+        int[] a = {6, 4};
+        assertTrue(LinkListSort.isSorted(a, 1));
+    }
+
+    @Test
+    void testForThreeElements() {
+        int[] a = {875, 253, 12};
+        assertTrue(LinkListSort.isSorted(a, 3));
+    }
+
+    @Test
+    void testForFourElements() {
+        int[] a = {86, 32, 87, 13};
+        assertTrue(LinkListSort.isSorted(a, 1));
+    }
+
+    @Test
+    void testForFiveElements() {
+        int[] a = {6, 5, 3, 0, 9};
+        assertTrue(LinkListSort.isSorted(a, 1));
+    }
+
+    @Test
+    void testForSixElements() {
+        int[] a = {9, 65, 432, 32, 47, 327};
+        assertTrue(LinkListSort.isSorted(a, 3));
+    }
+
+    @Test
+    void testForSevenElements() {
+        int[] a = {6, 4, 2, 1, 3, 6, 7};
+        assertTrue(LinkListSort.isSorted(a, 1));
+    }
+
+    @Test
+    void testForEightElements() {
+        int[] a = {123, 234, 145, 764, 322, 367, 768, 34};
+        assertTrue(LinkListSort.isSorted(a, 2));
+    }
+}

--- a/__mods2/disjoint_set.jl
+++ b/__mods2/disjoint_set.jl
@@ -1,0 +1,28 @@
+"""
+This can contain a maximum of `length(par)` parenting-relations
+par is an array of `Int`, which is the index of the parent node.
+"""
+mutable struct DisjointSet
+    par::Vector{Int}
+    function DisjointSet(size)
+        x = [i for i in 1:size]
+        return new(x)
+    end
+end
+
+"""
+Find the ancestor of node `x`.
+"""
+function find(set::DisjointSet, x::Int)::Int
+    if set.par[x] == x
+        return x
+    else
+        return set.par[x] = find(set, set.par[x])
+    end
+end
+
+function Base.merge!(set::DisjointSet, x::Int, y::Int)
+    x = find(set, x)
+    y = find(set, y)
+    return set.par[x] = y
+end


### PR DESCRIPTION
85 This is not a bug but rather expected behavior when using an unsupported Python version. Our documentation clearly states that Python 3.8+ is required, and the user was running 3.6 which reached end-of-life in December 2021.