### PR TITLE
Closes #90 Fix incorrect fallback behavior when backend is unavailable

### DIFF
--- a/__junk6/GCounterTest.java
+++ b/__junk6/GCounterTest.java
@@ -1,0 +1,56 @@
+package com.thealgorithms.datastructures.crdt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class GCounterTest {
+    @Test
+    void increment() {
+        GCounter counter = new GCounter(0, 3);
+        counter.increment();
+        counter.increment();
+        counter.increment();
+        assertEquals(3, counter.value());
+    }
+
+    @Test
+    void merge() {
+        GCounter counter1 = new GCounter(0, 3);
+        counter1.increment();
+        GCounter counter2 = new GCounter(1, 3);
+        counter2.increment();
+        counter2.increment();
+        GCounter counter3 = new GCounter(2, 3);
+        counter3.increment();
+        counter3.increment();
+        counter3.increment();
+        counter1.merge(counter2);
+        counter1.merge(counter3);
+        counter2.merge(counter1);
+        counter3.merge(counter2);
+        assertEquals(6, counter1.value());
+        assertEquals(6, counter2.value());
+        assertEquals(6, counter3.value());
+    }
+
+    @Test
+    void compare() {
+        GCounter counter1 = new GCounter(0, 5);
+        GCounter counter2 = new GCounter(3, 5);
+        counter1.increment();
+        counter1.increment();
+        counter2.merge(counter1);
+        counter2.increment();
+        counter2.increment();
+        assertTrue(counter1.compare(counter2));
+        counter1.increment();
+        counter2.increment();
+        counter2.merge(counter1);
+        assertTrue(counter1.compare(counter2));
+        counter1.increment();
+        assertFalse(counter1.compare(counter2));
+    }
+}

--- a/__junk6/PalindromeTest.java
+++ b/__junk6/PalindromeTest.java
@@ -1,0 +1,21 @@
+package com.thealgorithms.strings;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class PalindromeTest {
+    private static Stream<TestData> provideTestCases() {
+        return Stream.of(new TestData(null, true), new TestData("", true), new TestData("aba", true), new TestData("123321", true), new TestData("kayak", true), new TestData("abb", false), new TestData("abc", false), new TestData("abc123", false), new TestData("kayaks", false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void testPalindrome(TestData testData) {
+        Assertions.assertEquals(testData.expected, Palindrome.isPalindrome(testData.input) && Palindrome.isPalindromeRecursion(testData.input) && Palindrome.isPalindromeTwoPointer(testData.input));
+    }
+
+    private record TestData(String input, boolean expected) {
+    }
+}


### PR DESCRIPTION
90 Deprecated flags were removed from example configurations. This keeps examples aligned with supported functionality.