### PR TITLE
Closes #103 Document roadmap constraints leading to feature rejection

### DIFF
--- a/__mods4/AbsoluteValueTest.java
+++ b/__mods4/AbsoluteValueTest.java
@@ -1,0 +1,39 @@
+package com.thealgorithms.maths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+public class AbsoluteValueTest {
+
+    @Test
+    void testGetAbsValue() {
+        Stream.generate(() -> ThreadLocalRandom.current().nextInt()).limit(1000).forEach(number -> assertEquals(Math.abs(number), AbsoluteValue.getAbsValue(number)));
+    }
+
+    @Test
+    void testZero() {
+        assertEquals(0, AbsoluteValue.getAbsValue(0));
+    }
+
+    @Test
+    void testPositiveNumbers() {
+        assertEquals(5, AbsoluteValue.getAbsValue(5));
+        assertEquals(123456, AbsoluteValue.getAbsValue(123456));
+        assertEquals(Integer.MAX_VALUE, AbsoluteValue.getAbsValue(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void testNegativeNumbers() {
+        assertEquals(5, AbsoluteValue.getAbsValue(-5));
+        assertEquals(123456, AbsoluteValue.getAbsValue(-123456));
+        assertEquals(Integer.MAX_VALUE, AbsoluteValue.getAbsValue(-Integer.MAX_VALUE));
+    }
+
+    @Test
+    void testMinIntEdgeCase() {
+        assertEquals(Integer.MIN_VALUE, AbsoluteValue.getAbsValue(Integer.MIN_VALUE));
+    }
+}

--- a/__mods4/BinaryLifting.test.js
+++ b/__mods4/BinaryLifting.test.js
@@ -1,0 +1,82 @@
+import binaryLifting from '../BinaryLifting'
+
+// The graph for Test Case 1 looks like this:
+//
+//         0
+//        /|\
+//       / | \
+//      1  3  5
+//     / \     \
+//    2   4     6
+//         \
+//          7
+//         / \
+//        11  8
+//             \
+//              9
+//               \
+//                10
+
+test('Test case 1', () => {
+  const root = 0
+  const graph = [
+    [0, 1],
+    [0, 3],
+    [0, 5],
+    [5, 6],
+    [1, 2],
+    [1, 4],
+    [4, 7],
+    [7, 11],
+    [7, 8],
+    [8, 9],
+    [9, 10]
+  ]
+  const queries = [
+    [2, 1],
+    [6, 1],
+    [7, 2],
+    [8, 2],
+    [10, 2],
+    [10, 3],
+    [10, 5],
+    [11, 3]
+  ]
+  const kthAncestors = binaryLifting(root, graph, queries)
+  expect(kthAncestors).toEqual([1, 5, 1, 4, 8, 7, 1, 1])
+})
+
+// The graph for Test Case 2 looks like this:
+//
+//         0
+//        / \
+//       1   2
+//      / \   \
+//     3   4   5
+//    /       / \
+//   6       7   8
+
+test('Test case 2', () => {
+  const root = 0
+  const graph = [
+    [0, 1],
+    [0, 2],
+    [1, 3],
+    [1, 4],
+    [2, 5],
+    [3, 6],
+    [5, 7],
+    [5, 8]
+  ]
+  const queries = [
+    [2, 1],
+    [3, 1],
+    [3, 2],
+    [6, 2],
+    [7, 3],
+    [8, 2],
+    [8, 3]
+  ]
+  const kthAncestors = binaryLifting(root, graph, queries)
+  expect(kthAncestors).toEqual([0, 1, 0, 1, 0, 2, 0])
+})

--- a/__mods4/LeonardoNumberTest.java
+++ b/__mods4/LeonardoNumberTest.java
@@ -1,0 +1,171 @@
+package com.thealgorithms.maths;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link LeonardoNumber} class.
+ * <p>
+ * Tests both recursive and iterative implementations with various input values
+ * including edge cases and boundary conditions.
+ */
+class LeonardoNumberTest {
+
+    // Tests for recursive implementation
+
+    @Test
+    void testLeonardoNumberNegative() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LeonardoNumber.leonardoNumber(-1));
+    }
+
+    @Test
+    void testLeonardoNumberNegativeLarge() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LeonardoNumber.leonardoNumber(-100));
+    }
+
+    @Test
+    void testLeonardoNumberZero() {
+        Assertions.assertEquals(1, LeonardoNumber.leonardoNumber(0));
+    }
+
+    @Test
+    void testLeonardoNumberOne() {
+        Assertions.assertEquals(1, LeonardoNumber.leonardoNumber(1));
+    }
+
+    @Test
+    void testLeonardoNumberTwo() {
+        Assertions.assertEquals(3, LeonardoNumber.leonardoNumber(2));
+    }
+
+    @Test
+    void testLeonardoNumberThree() {
+        Assertions.assertEquals(5, LeonardoNumber.leonardoNumber(3));
+    }
+
+    @Test
+    void testLeonardoNumberFour() {
+        Assertions.assertEquals(9, LeonardoNumber.leonardoNumber(4));
+    }
+
+    @Test
+    void testLeonardoNumberFive() {
+        Assertions.assertEquals(15, LeonardoNumber.leonardoNumber(5));
+    }
+
+    @Test
+    void testLeonardoNumberSix() {
+        Assertions.assertEquals(25, LeonardoNumber.leonardoNumber(6));
+    }
+
+    @Test
+    void testLeonardoNumberSeven() {
+        Assertions.assertEquals(41, LeonardoNumber.leonardoNumber(7));
+    }
+
+    @Test
+    void testLeonardoNumberEight() {
+        Assertions.assertEquals(67, LeonardoNumber.leonardoNumber(8));
+    }
+
+    @Test
+    void testLeonardoNumberTen() {
+        Assertions.assertEquals(177, LeonardoNumber.leonardoNumber(10));
+    }
+
+    @Test
+    void testLeonardoNumberFifteen() {
+        Assertions.assertEquals(1973, LeonardoNumber.leonardoNumber(15));
+    }
+
+    @Test
+    void testLeonardoNumberTwenty() {
+        Assertions.assertEquals(21891, LeonardoNumber.leonardoNumber(20));
+    }
+
+    // Tests for iterative implementation
+
+    @Test
+    void testLeonardoNumberIterativeNegative() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LeonardoNumber.leonardoNumberIterative(-1));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeNegativeLarge() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LeonardoNumber.leonardoNumberIterative(-50));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeZero() {
+        Assertions.assertEquals(1, LeonardoNumber.leonardoNumberIterative(0));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeOne() {
+        Assertions.assertEquals(1, LeonardoNumber.leonardoNumberIterative(1));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeTwo() {
+        Assertions.assertEquals(3, LeonardoNumber.leonardoNumberIterative(2));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeThree() {
+        Assertions.assertEquals(5, LeonardoNumber.leonardoNumberIterative(3));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeFour() {
+        Assertions.assertEquals(9, LeonardoNumber.leonardoNumberIterative(4));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeFive() {
+        Assertions.assertEquals(15, LeonardoNumber.leonardoNumberIterative(5));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeSix() {
+        Assertions.assertEquals(25, LeonardoNumber.leonardoNumberIterative(6));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeSeven() {
+        Assertions.assertEquals(41, LeonardoNumber.leonardoNumberIterative(7));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeEight() {
+        Assertions.assertEquals(67, LeonardoNumber.leonardoNumberIterative(8));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeTen() {
+        Assertions.assertEquals(177, LeonardoNumber.leonardoNumberIterative(10));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeFifteen() {
+        Assertions.assertEquals(1973, LeonardoNumber.leonardoNumberIterative(15));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeTwenty() {
+        Assertions.assertEquals(21891, LeonardoNumber.leonardoNumberIterative(20));
+    }
+
+    @Test
+    void testLeonardoNumberIterativeTwentyFive() {
+        Assertions.assertEquals(242785, LeonardoNumber.leonardoNumberIterative(25));
+    }
+
+    // Consistency tests between recursive and iterative implementations
+
+    @Test
+    void testConsistencyBetweenImplementations() {
+        for (int i = 0; i <= 15; i++) {
+            Assertions.assertEquals(LeonardoNumber.leonardoNumber(i), LeonardoNumber.leonardoNumberIterative(i), "Mismatch at index " + i);
+        }
+    }
+}

--- a/__mods4/SkipListNode.cs
+++ b/__mods4/SkipListNode.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+
+namespace DataStructures.LinkedList.SkipList;
+
+[DebuggerDisplay("Key = {Key}, Height = {Height}, Value = {Value}")]
+internal class SkipListNode<TValue>(int key, TValue? value, int height)
+{
+    public int Key { get; } = key;
+
+    public TValue? Value { get; set; } = value;
+
+    public SkipListNode<TValue>[] Next { get; } = new SkipListNode<TValue>[height];
+
+    public int Height { get; } = height;
+}

--- a/__mods4/brightness.m
+++ b/__mods4/brightness.m
@@ -1,0 +1,49 @@
+function y = brightness(red, green, blue)
+  % brightness: returns 1 if the color is light otherwise 0
+  % INPUT: RGB-value of the color (red, green, blue)
+  % OUTPUT: 0 or 1 (0 dark, 1 light)
+  % The function used the nearest neighbor algorithm
+
+  % train set for various rgb-values and its brightness
+  % the set contains vectors with dimension 4x1
+  % [r, g, b, brightness]
+  train_set = [2, 99, 255, 1;
+            37,44,58,0;
+            139, 169, 229,1;
+            14, 255, 10, 1;
+            2, 28, 1, 0;
+            20, 33, 20, 0;
+            252, 227, 65,1;
+            71, 65, 24, 0;
+            168, 80, 80,1;
+            119, 35, 90, 0; 
+            186, 13, 126, 1;];
+            
+  function length = eulidean(v1, v2)
+    % eulidean: calculates the eulidean length between two vectors (3x1)
+    % The calculation contains only the RGB-values! (3x1)
+    % HELPER-FUNCTION
+    length = sqrt((v2(1)-v1(1))^2 + (v2(2)-v1(2))^2 + (v2(3)-v1(3))^2);
+  endfunction
+  
+  
+  rgb = [red green blue];
+  x1 = train_set(1,:);
+  x2 = x1(1:3);
+  min = eulidean(rgb,x2);
+  index = 1;
+  
+  for i = 2:length(train_set)
+    x1 = train_set(i,:);
+    x2 = x1(1:3);
+    result = eulidean(rgb,x2);
+    if (result < min)
+      min = result;
+      index = i;
+    end
+  end
+  
+  y = train_set(index,:)(4);
+            
+
+endfunction

--- a/__mods4/logistic_regression.rs
+++ b/__mods4/logistic_regression.rs
@@ -1,0 +1,92 @@
+use super::optimization::gradient_descent;
+use std::f64::consts::E;
+
+/// Returns the weights after performing Logistic regression on the input data points.
+pub fn logistic_regression(
+    data_points: Vec<(Vec<f64>, f64)>,
+    iterations: usize,
+    learning_rate: f64,
+) -> Option<Vec<f64>> {
+    if data_points.is_empty() {
+        return None;
+    }
+
+    let num_features = data_points[0].0.len() + 1;
+    let mut params = vec![0.0; num_features];
+
+    let derivative_fn = |params: &[f64]| derivative(params, &data_points);
+
+    gradient_descent(derivative_fn, &mut params, learning_rate, iterations as i32);
+
+    Some(params)
+}
+
+fn derivative(params: &[f64], data_points: &[(Vec<f64>, f64)]) -> Vec<f64> {
+    let num_features = params.len();
+    let mut gradients = vec![0.0; num_features];
+
+    for (features, y_i) in data_points {
+        let z = params[0]
+            + params[1..]
+                .iter()
+                .zip(features)
+                .map(|(p, x)| p * x)
+                .sum::<f64>();
+        let prediction = 1.0 / (1.0 + E.powf(-z));
+
+        gradients[0] += prediction - y_i;
+        for (i, x_i) in features.iter().enumerate() {
+            gradients[i + 1] += (prediction - y_i) * x_i;
+        }
+    }
+
+    gradients
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_logistic_regression_simple() {
+        let data = vec![
+            (vec![0.0], 0.0),
+            (vec![1.0], 0.0),
+            (vec![2.0], 0.0),
+            (vec![3.0], 1.0),
+            (vec![4.0], 1.0),
+            (vec![5.0], 1.0),
+        ];
+
+        let result = logistic_regression(data, 10000, 0.05);
+        assert!(result.is_some());
+
+        let params = result.unwrap();
+        assert!((params[0] + 17.65).abs() < 1.0);
+        assert!((params[1] - 7.13).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_logistic_regression_extreme_data() {
+        let data = vec![
+            (vec![-100.0], 0.0),
+            (vec![-10.0], 0.0),
+            (vec![0.0], 0.0),
+            (vec![10.0], 1.0),
+            (vec![100.0], 1.0),
+        ];
+
+        let result = logistic_regression(data, 10000, 0.05);
+        assert!(result.is_some());
+
+        let params = result.unwrap();
+        assert!((params[0] + 6.20).abs() < 1.0);
+        assert!((params[1] - 5.5).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_logistic_regression_no_data() {
+        let result = logistic_regression(vec![], 5000, 0.1);
+        assert_eq!(result, None);
+    }
+}


### PR DESCRIPTION
103 This change cleans up redundant warnings that were emitted from multiple layers. The messages are now centralized and emitted once. This improves log clarity.